### PR TITLE
Try to improve deletion time estimate

### DIFF
--- a/manifest_translator.py
+++ b/manifest_translator.py
@@ -108,12 +108,7 @@ def parse_data(file_path):
         if dictkey in manifestDict:
           # There is no deletion timestamp in the trace. However we know that
           # files become obsolete as soon as compaction finishes, which is
-          # approximately the time the last file was created by compaction.
-          #
-          # If the below assertion fails, it means there is a VersionEdit that
-          # only contains DeleteFile entries. If we need to handle that case, we
-          # should probably estimate deletion time according to AddFile entries
-          # in an adjacent VersionEdit.
+          # approximately the time the last file was created.
           assert LatestAddTime != -1
           manifestDict[dictkey].Deletion = LatestAddTime
         else:
@@ -121,7 +116,6 @@ def parse_data(file_path):
         
       AddInfoArr = []
       DeleteInfoArr = []
-      LatestAddTime = -1
       
     line = f.readline()
   f.close()

--- a/manifest_translator.py
+++ b/manifest_translator.py
@@ -63,7 +63,7 @@ def parse_data(file_path):
 
   AddInfoArr = []
   DeleteInfoArr = []
-  TmpTime = []
+  LatestAddTime = -1
 
   line = f.readline()
   while True:
@@ -82,14 +82,13 @@ def parse_data(file_path):
           Creation = int(item.split(":")[1])
           break
       AddInfoArr.append(AddInfo(Level, ID, Size, StartKey, EndKey, Creation))
-      TmpTime.append(Creation)
+      LatestAddTime = max(LatestAddTime, Creation)
     elif "DeleteFile:" in line:
       data = line.split()
       DeleteInfoArr.append(DeleteInfo(data[1], data[2]))
     elif "ColumnFamily:" in line:
       data = line.split()
       curCF = int(data[1])
-      idx = 0
       
       for AddItem in AddInfoArr:
         dictkey = getDictKey(AddItem.Level, AddItem.ID, curCF)
@@ -107,15 +106,22 @@ def parse_data(file_path):
       for DeletedItem in DeleteInfoArr:
         dictkey = getDictKey(DeletedItem.Level, DeletedItem.ID, curCF)
         if dictkey in manifestDict:
-          manifestDict[dictkey].Deletion = TmpTime[idx]
-          if idx < len(TmpTime) - 1:
-            idx += 1
+          # There is no deletion timestamp in the trace. However we know that
+          # files become obsolete as soon as compaction finishes, which is
+          # approximately the time the last file was created by compaction.
+          #
+          # If the below assertion fails, it means there is a VersionEdit that
+          # only contains DeleteFile entries. If we need to handle that case, we
+          # should probably estimate deletion time according to AddFile entries
+          # in an adjacent VersionEdit.
+          assert LatestAddTime != -1
+          manifestDict[dictkey].Deletion = LatestAddTime
         else:
           print("deletion log: missing SST!")
         
       AddInfoArr = []
       DeleteInfoArr = []
-      TmpTime = []
+      LatestAddTime = -1
       
     line = f.readline()
   f.close()


### PR DESCRIPTION
A VersionEdit with DeleteFile entries is the result of a compaction. Compaction does not delete any files until after all new files have been created. So I think a better estimate of the deletion time would be the time the compaction adds the newest file.

In very rare cases a VersionEdit may contain only DeleteFile entries. In those cases I used the most recent AddFile timestamp. That timestamp is from an earlier compaction so could be old.